### PR TITLE
[FIX] Update resume links to simonrowe.dev

### DIFF
--- a/modules/backend/src/main/java/com/simonjamesrowe/backend/dataproviders/cms/CmsResumeRepository.java
+++ b/modules/backend/src/main/java/com/simonjamesrowe/backend/dataproviders/cms/CmsResumeRepository.java
@@ -48,7 +48,7 @@ public class CmsResumeRepository implements ResumeRepository {
                                      List<SocialMediaResponseDTO> socialMedias, List<SkillResponseDTO> skills) {
 
         List<ResumeData.Link> links = new ArrayList<>();
-        links.add(new ResumeData.Link("www.simonjamesrowe.com"));
+        links.add(new ResumeData.Link("http://simonrowe.dev"));
         socialMedias.stream()
                 .filter(SocialMediaResponseDTO::includeOnResume)
                 .map(sm -> new ResumeData.Link(sm.link()))
@@ -84,7 +84,7 @@ public class CmsResumeRepository implements ResumeRepository {
         return new ResumeData.Job(
                 response.title(),
                 response.company(),
-                "https://www.simonjamesrowe.com/jobs/" + response.id(),
+                "http://simonrowe.dev/jobs/" + response.id(),
                 response.startDate(),
                 response.endDate(),
                 response.shortDescription(),

--- a/modules/backend/src/test/java/com/simonjamesrowe/backend/test/dataproviders/cms/CmsResumeRepositoryTest.java
+++ b/modules/backend/src/test/java/com/simonjamesrowe/backend/test/dataproviders/cms/CmsResumeRepositoryTest.java
@@ -54,7 +54,7 @@ class CmsResumeRepositoryTest {
         assertThat(result.getJobs().get(0)).hasFieldOrPropertyWithValue("company", "Y-Tree");
         assertThat(result.getJobs().get(0)).hasFieldOrPropertyWithValue(
             "link",
-            "https://www.simonjamesrowe.com/jobs/5eedd4803c8d74001e4497f5"
+            "http://simonrowe.dev/jobs/5eedd4803c8d74001e4497f5"
         );
         assertThat(result.getJobs().get(0)).hasFieldOrPropertyWithValue("start", LocalDate.parse("2020-05-04"));
         assertThat(result.getJobs().get(0)).hasFieldOrPropertyWithValue("location", "London");

--- a/modules/backend/src/test/resources/social-media.json
+++ b/modules/backend/src/test/resources/social-media.json
@@ -31,7 +31,7 @@
     "includeOnResume": true,
     "_id": "5f63627e5ee4c9001d2b9673",
     "link": "https://github.com/simonjamesrowe",
-    "name": "Public org for all repos that make up www.simonjamesrowe.com",
+    "name": "Public org for all repos that make up simonrowe.dev",
     "createdAt": "2020-09-17T13:19:58.141Z",
     "updatedAt": "2021-02-26T07:03:13.133Z",
     "__v": 0,


### PR DESCRIPTION
## Summary
- switch resume URLs over to simonrowe.dev
- align tests and fixtures with new domain

## Deployment Notes
- None

## Screenshots / Payloads (when relevant)
- N/A